### PR TITLE
Fix code scanning alert - useless conversion to the same type: std::collections::hash_map::Values<'_, build::bonus::types::...

### DIFF
--- a/src/build/bonus/breakdowns/mod.rs
+++ b/src/build/bonus/breakdowns/mod.rs
@@ -35,7 +35,7 @@ impl Breakdowns {
                 values.insert(bonus.get_bonus_type(), bonus.get_value());
             }
         }
-        values.values().into_iter().sum()
+        values.values().sum()
     }
 
     pub fn insert_attributes(&mut self, attributes: Vec<Bonus>) {


### PR DESCRIPTION
Fixes #3