### PR TITLE
feat(builder): Added Value::If conditional

### DIFF
--- a/builder/src/attribute/types/armor_class.rs
+++ b/builder/src/attribute/types/armor_class.rs
@@ -125,26 +125,20 @@ impl DefaultBonuses for ArmorClass {
                     ]),
                 ])),
             ),
-            // If there is a max dex bonus
             Bonus::new(
                 Self::Bonus.into(),
                 BonusType::AbilityModifier,
-                Value::Min(vec![
-                    Attribute::AbilityModifier(Ability::Dexterity).into(),
-                    Attribute::ArmorClass(Self::CalculatedMaxDexBonus).into(),
-                ]),
+                Value::If(
+                    Condition::has(Attribute::ArmorClass(Self::CalculatedMaxDexBonus)).into(),
+                    Value::Min(vec![
+                        Attribute::AbilityModifier(Ability::Dexterity).into(),
+                        Attribute::ArmorClass(Self::CalculatedMaxDexBonus).into(),
+                    ])
+                    .into(),
+                    Value::from(Attribute::AbilityModifier(Ability::Dexterity)).into(),
+                ),
                 BonusSource::Base,
-                Some(Condition::has(Attribute::ArmorClass(
-                    Self::CalculatedMaxDexBonus,
-                ))),
-            ),
-            // If there is not a max dex bonus
-            Bonus::new(
-                Self::Bonus.into(),
-                BonusType::AbilityModifier,
-                Attribute::AbilityModifier(Ability::Dexterity).into(),
-                BonusSource::Base,
-                Some(Condition::not_have(Self::CalculatedMaxDexBonus.into())),
+                None,
             ),
         ]
     }

--- a/builder/src/bonus/condition.rs
+++ b/builder/src/bonus/condition.rs
@@ -7,7 +7,7 @@ use crate::attribute::{Attribute, AttributeDependencies};
 use super::Value;
 
 /// Describes an attribute-based condition that must be met for a bonus to be included.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Condition {
     /// Requires that a condition is not true
     Not(Box<Condition>),

--- a/builder/src/bonus/value.rs
+++ b/builder/src/bonus/value.rs
@@ -176,4 +176,82 @@ mod tests {
             }
         });
     }
+
+    mod dependencies {
+        use super::*;
+
+        mod has_dependency {
+            use super::*;
+
+            #[test]
+            fn value() {
+                let value = Value::Value(10f32);
+
+                assert!(!value.has_attr_dependency(Attribute::Debug(0)));
+            }
+
+            #[test]
+            fn attribute() {
+                let value = Value::Attribute(Attribute::Debug(0));
+
+                assert!(value.has_attr_dependency(Attribute::Debug(0)));
+                assert!(!value.has_attr_dependency(Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn sum() {
+                let value = Value::Sum(vec![Attribute::Debug(0).into(), 10f32.into()]);
+
+                assert!(value.has_attr_dependency(Attribute::Debug(0)));
+                assert!(!value.has_attr_dependency(Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn product() {
+                let value = Value::Product(vec![Attribute::Debug(0).into(), 10f32.into()]);
+
+                assert!(value.has_attr_dependency(Attribute::Debug(0)));
+                assert!(!value.has_attr_dependency(Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn min() {
+                let value = Value::Min(vec![Attribute::Debug(0).into(), 10f32.into()]);
+
+                assert!(value.has_attr_dependency(Attribute::Debug(0)));
+                assert!(!value.has_attr_dependency(Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn max() {
+                let value = Value::Max(vec![Attribute::Debug(0).into(), Attribute::Debug(1).into()]);
+
+                assert!(value.has_attr_dependency(Attribute::Debug(0)));
+                assert!(value.has_attr_dependency(Attribute::Debug(1)));
+                assert!(!value.has_attr_dependency(Attribute::Debug(2)));
+            }
+
+            #[test]
+            fn floor() {
+                let value = Value::Floor(Value::Attribute(Attribute::Debug(0)).into());
+
+                assert!(value.has_attr_dependency(Attribute::Debug(0)));
+                assert!(!value.has_attr_dependency(Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn if_value() {
+                let value = Value::If(
+                    Condition::GreaterThan(Attribute::Debug(0).into(), 1f32.into()).into(),
+                    Value::from(Attribute::Debug(1)).into(),
+                    Value::from(Attribute::Debug(2)).into()
+                );
+
+                assert!(value.has_attr_dependency(Attribute::Debug(0)));
+                assert!(value.has_attr_dependency(Attribute::Debug(1)));
+                assert!(value.has_attr_dependency(Attribute::Debug(2)));
+                assert!(!value.has_attr_dependency(Attribute::Debug(3)));
+            }
+        }
+    }
 }

--- a/builder/src/bonus/value.rs
+++ b/builder/src/bonus/value.rs
@@ -224,7 +224,8 @@ mod tests {
 
             #[test]
             fn max() {
-                let value = Value::Max(vec![Attribute::Debug(0).into(), Attribute::Debug(1).into()]);
+                let value =
+                    Value::Max(vec![Attribute::Debug(0).into(), Attribute::Debug(1).into()]);
 
                 assert!(value.has_attr_dependency(Attribute::Debug(0)));
                 assert!(value.has_attr_dependency(Attribute::Debug(1)));
@@ -244,13 +245,103 @@ mod tests {
                 let value = Value::If(
                     Condition::GreaterThan(Attribute::Debug(0).into(), 1f32.into()).into(),
                     Value::from(Attribute::Debug(1)).into(),
-                    Value::from(Attribute::Debug(2)).into()
+                    Value::from(Attribute::Debug(2)).into(),
                 );
 
                 assert!(value.has_attr_dependency(Attribute::Debug(0)));
                 assert!(value.has_attr_dependency(Attribute::Debug(1)));
                 assert!(value.has_attr_dependency(Attribute::Debug(2)));
                 assert!(!value.has_attr_dependency(Attribute::Debug(3)));
+            }
+        }
+
+        mod include_dependencies {
+            use super::*;
+
+            #[test]
+            fn value() {
+                let value = Value::Value(10f32);
+                let deps = value.get_attr_dependencies();
+
+                assert!(!deps.contains(&Attribute::Debug(0)));
+            }
+
+            #[test]
+            fn attribute() {
+                let value = Value::Attribute(Attribute::Debug(0));
+
+                let deps = value.get_attr_dependencies();
+
+                assert!(deps.contains(&Attribute::Debug(0)));
+                assert!(!deps.contains(&Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn sum() {
+                let value = Value::Sum(vec![Attribute::Debug(0).into(), 10f32.into()]);
+
+                let deps = value.get_attr_dependencies();
+
+                assert!(deps.contains(&Attribute::Debug(0)));
+                assert!(!deps.contains(&Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn product() {
+                let value = Value::Product(vec![Attribute::Debug(0).into(), 10f32.into()]);
+
+                let deps = value.get_attr_dependencies();
+
+                assert!(deps.contains(&Attribute::Debug(0)));
+                assert!(!deps.contains(&Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn min() {
+                let value = Value::Min(vec![Attribute::Debug(0).into(), 10f32.into()]);
+
+                let deps = value.get_attr_dependencies();
+
+                assert!(deps.contains(&Attribute::Debug(0)));
+                assert!(!deps.contains(&Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn max() {
+                let value =
+                    Value::Max(vec![Attribute::Debug(0).into(), Attribute::Debug(1).into()]);
+
+                let deps = value.get_attr_dependencies();
+
+                assert!(deps.contains(&Attribute::Debug(0)));
+                assert!(deps.contains(&Attribute::Debug(1)));
+                assert!(!deps.contains(&Attribute::Debug(2)));
+            }
+
+            #[test]
+            fn floor() {
+                let value = Value::Floor(Value::Attribute(Attribute::Debug(0)).into());
+
+                let deps = value.get_attr_dependencies();
+
+                assert!(deps.contains(&Attribute::Debug(0)));
+                assert!(!deps.contains(&Attribute::Debug(1)));
+            }
+
+            #[test]
+            fn if_value() {
+                let value = Value::If(
+                    Condition::GreaterThan(Attribute::Debug(0).into(), 1f32.into()).into(),
+                    Value::from(Attribute::Debug(1)).into(),
+                    Value::from(Attribute::Debug(2)).into(),
+                );
+
+                let deps = value.get_attr_dependencies();
+
+                assert!(deps.contains(&Attribute::Debug(0)));
+                assert!(deps.contains(&Attribute::Debug(1)));
+                assert!(deps.contains(&Attribute::Debug(2)));
+                assert!(!deps.contains(&Attribute::Debug(3)));
             }
         }
     }

--- a/builder/src/compiler/calculation.rs
+++ b/builder/src/compiler/calculation.rs
@@ -67,6 +67,13 @@ impl Compiler {
                 })
             }
             Value::Floor(val) => self.calculate_value(val).floor(),
+            Value::If(cond, if_true, if_false) => {
+                if self.check_condition(cond) {
+                    self.calculate_value(if_true)
+                } else {
+                    self.calculate_value(if_false)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
`Value::If` allows bonuses to have conditional bonus values. As an example, the armor class bonuses that check if there's a maximum dexterity bonus use this new feature instead of needing two separate bonuses:

```rust
Bonus::new(
    Self::Bonus.into(),
    BonusType::AbilityModifier,
    Value::If(
        Condition::has(Attribute::ArmorClass(Self::CalculatedMaxDexBonus)).into(),
        Value::Min(vec![
            Attribute::AbilityModifier(Ability::Dexterity).into(),
            Attribute::ArmorClass(Self::CalculatedMaxDexBonus).into(),
        ])
        .into(),
        Value::from(Attribute::AbilityModifier(Ability::Dexterity)).into(),
    ),
    BonusSource::Base,
    None,
),
```

The form of `Value::If` is:

```rust
Value::If(condition, if_true, if_false)
```