### PR TITLE
chore(github): Move clippy config into workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,8 +71,8 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    # env:
-    #   RUSTFLAGS: -D warnings -D clippy::complexity -D clippy::pedantic -D clippy::nursery
+    env:
+      RUSTFLAGS: -D warnings -D clippy::complexity -D clippy::pedantic -D clippy::nursery
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -93,6 +93,6 @@ fn main() {
     ]);
 
     for (attr, val) in compiler.get_all_attributes() {
-        println!("{}: {}", attr, val);
+        println!("{attr}: {val}");
     }
 }

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs, clippy::pedantic, clippy::nursery)]
+#![warn(missing_docs)]
 #![allow(
     dead_code,
     clippy::must_use_candidate,

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs, clippy::pedantic, clippy::nursery)]
+#![warn(missing_docs)]
 #![allow(
     dead_code,
     clippy::must_use_candidate,


### PR DESCRIPTION
Instead of having the configuration in individual lib.rs, instead have the configuration as part of the workflow itself